### PR TITLE
Time Stamp DVL Data Fix

### DIFF
--- a/include/dvl_a50/dvl-sensor.hpp
+++ b/include/dvl_a50/dvl-sensor.hpp
@@ -57,7 +57,6 @@ public:
 private:
     int fault = 1; 
     string delimiter = ",";
-    double old_altitude;
     std::string ip_address;
     std::string velocity_frame_id;
     std::string position_frame_id;

--- a/src/dvl-sensor.cpp
+++ b/src/dvl-sensor.cpp
@@ -11,8 +11,7 @@ namespace dvl_sensor {
 
 
 DVL_A50::DVL_A50():
-Node("dvl_a50_node"),
-old_altitude(0.0)
+Node("dvl_a50_node")
 {
     rmw_qos_profile_t qos_profile = rmw_qos_profile_sensor_data;
 
@@ -166,11 +165,10 @@ void DVL_A50::publish_vel_trans_report()
     dvl.fom = double(json_data["fom"]);
     double current_altitude = double(json_data["altitude"]);
     dvl.velocity_valid = json_data["velocity_valid"];
-		    
-    if(current_altitude >= 0.0 && dvl.velocity_valid)
-        old_altitude = dvl.altitude = current_altitude;
-    else
-        dvl.altitude = old_altitude;
+    
+    // Removed logic to add old altitude if not valid. Does not report accurately what is coming from the DVL.
+    // Logic should be implemented on a case by case basis.
+    dvl.altitude = current_altitude;
 
 
     dvl.status = json_data["status"];

--- a/src/dvl-sensor.cpp
+++ b/src/dvl-sensor.cpp
@@ -157,6 +157,9 @@ void DVL_A50::publish_vel_trans_report()
     dvl.header.frame_id = velocity_frame_id;
 		
     dvl.time = double(json_data["time"]);
+    dvl.time_of_validity = json_data["time_of_validity"].get<int64_t>();
+    dvl.time_of_transmission = json_data["time_of_transmission"].get<int64_t>();
+
     dvl.velocity.x = double(json_data["vx"]);
     dvl.velocity.y = double(json_data["vy"]);
     dvl.velocity.z = double(json_data["vz"]);
@@ -172,6 +175,22 @@ void DVL_A50::publish_vel_trans_report()
 
     dvl.status = json_data["status"];
     dvl.form = json_data["format"];
+
+    // Add covariance from message
+    std::vector<double> twistCovariance;
+
+    if (json_data.contains("covariance") && json_data["covariance"].is_array()) {
+        const auto& matrix = json_data["covariance"];
+        
+        for (const auto& row : matrix) {
+            if (!row.is_array()) continue;
+            for (const auto& value : row) {
+                twistCovariance.push_back(value.get<double>());
+            }
+        }
+    }
+
+    dvl.covariance = twistCovariance;
 			
     beam0.id = json_data["transducers"][0]["id"];
     beam0.velocity = double(json_data["transducers"][0]["velocity"]);


### PR DESCRIPTION
Corresponding pull request will be made on dvl-msgs driver.

The time reported in the message was the "Milliseconds since last velocity report (ms)" not the actual time reported by the DVL when it recorded the measurement.

This is crucial for anyone using the NTP time sync to get accurate timestamps associated with the data.

Helpful for anyone using this with state estimation tasks with precise timing.

Additionally removed old altitude logic